### PR TITLE
Adding some checks and disabling prometheus by default

### DIFF
--- a/channels/console.py
+++ b/channels/console.py
@@ -45,11 +45,20 @@ class ConsoleInput(InputChannel):
         @custom_webhook.route("/talk", methods=["POST"])
         async def receive(request: Request) -> HTTPResponse:
             identity = self.extract_identity(request)
+            if not identity:
+                return response.json({"error": "No x-rh-identity header present"}, status=400)
+
             sender_id = self.get_sender(identity)
             if not sender_id:
-                return response.json({"error": "Invalid x-rh-identity header (no user_id found)"})
+                return response.json({"error": "Invalid x-rh-identity header (no user_id found)"}, status=400)
+
+            if not request.json:
+                return response.json({"error": "Invalid body"}, status=400)
 
             message = request.json.get("message")
+            if not message:
+                return response.json({"error": "Invalid json body"}, status=400)
+
             input_channel = self.name()
 
             collector = CollectingOutputChannel()

--- a/common/config.py
+++ b/common/config.py
@@ -29,7 +29,7 @@ def initialize_clowdapp():
     NAMESPACE = get_namespace()
     HOSTNAME = os.environ.get("HOSTNAME")
 
-    PROMETHEUS = os.getenv("PROMETHEUS", "True")
+    PROMETHEUS = os.getenv("PROMETHEUS", "false")
 
 def log_config():
     import sys
@@ -69,5 +69,5 @@ else:
     CW_AWS_SECRET_ACCESS_KEY = os.getenv("CW_AWS_SECRET_ACCESS_KEY", None)
     LOG_GROUP = os.getenv("LOG_GROUP", "platform-dev")
     # Metrics
-    PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", 8080))
-    API_PORT = int(os.getenv("API_PORT", 5000))
+    PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", 9000))
+    API_PORT = int(os.getenv("API_PORT", 5005))


### PR DESCRIPTION
* Throwing `400` for invalid requests in the api
* Disabling prometheus by default, we don't need it during local development. We will enable it in the cluster.
* Setting Prometheus port to `9000`. `9000` seems to be the standard in the platform.