### PR TITLE
Using one metric to track all custom action triggers

### DIFF
--- a/actions/closing_actions.py
+++ b/actions/closing_actions.py
@@ -5,6 +5,8 @@ from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import Action
 from rasa_sdk.events import SlotSet
 
+from common import metrics
+
 
 class ActionGotHelp(Action):
     def name(self) -> Text:
@@ -13,6 +15,8 @@ class ActionGotHelp(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
+        metrics.action_custom_action_count.labels(action_type=self.name()).inc()
+
         last_intent = tracker.get_intent_of_latest_message(True)
         if last_intent == "intent_core_yes":
             return [SlotSet("closing_got_help", True)]
@@ -29,5 +33,6 @@ class ActionShareFeedback(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
+        metrics.action_custom_action_count.labels(action_type=self.name()).inc()
         # Todo: Insert logic to send feedback to the platform
         return [SlotSet("closing_feedback", None)]

--- a/actions/core_actions.py
+++ b/actions/core_actions.py
@@ -5,6 +5,7 @@ from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import Action
 from rasa_sdk.events import SlotSet, UserUtteranceReverted
 
+from common import metrics
 from actions.utils import get_current_url
 
 _SLOT_FIRST_TIME_GREETING = "first_time_greeting"
@@ -22,6 +23,7 @@ class ActionBack(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
+        metrics.action_custom_action_count.labels(action_type=self.name()).inc()
         return [UserUtteranceReverted()]
 
 
@@ -34,6 +36,8 @@ class ActionPreProcess(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
+        metrics.action_custom_action_count.labels(action_type=self.name()).inc()
+
         results = []
 
         # Set the first_time_greeting slot to False on a user interaction

--- a/actions/current_url.py
+++ b/actions/current_url.py
@@ -5,6 +5,7 @@ from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import Action
 from rasa_sdk.events import SlotSet
 
+from common import metrics
 from .utils import is_user_event
 
 
@@ -18,6 +19,8 @@ class ActionSetCurrentURL(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
+        metrics.action_custom_action_count.labels(action_type=self.name()).inc()
+
         # find latest 'user' event
         latest_user_event = next(filter(is_user_event, reversed(tracker.events)), None)
 

--- a/actions/default_actions.py
+++ b/actions/default_actions.py
@@ -30,7 +30,7 @@ class ActionSessionStarted(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
-        metrics.action_session_start.inc()
+        metrics.action_custom_action_count.labels(action_type=self.name()).inc()
         return [
             SessionStarted(),
             *self.fetch_slots(tracker),

--- a/actions/services_offline.py
+++ b/actions/services_offline.py
@@ -5,6 +5,8 @@ from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import Action
 import requests
 
+from common import metrics
+
 class ActionServicesOffline(Action):
 
     def name(self) -> Text:
@@ -13,8 +15,10 @@ class ActionServicesOffline(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
-        
+        metrics.action_custom_action_count.labels(action_type=self.name()).inc()
+
         result = None
+
         try:
             result = requests.get(
                 "https://status.redhat.com/api/v2/incidents/unresolved.json"

--- a/common/metrics.py
+++ b/common/metrics.py
@@ -1,6 +1,8 @@
 from prometheus_client import Counter
 
 # Counters
-action_session_start = Counter(
-    "virtual_assistant_action_session_start_count", "Total number of session starts"
+action_custom_action_count = Counter(
+    "virtual_assistant_custom_action_count",
+    "Total number of custom actions triggered",
+    ["action_type"],
 )


### PR DESCRIPTION
Replacing the previous `action_session_start` with a more generic `action_custom_action_count`. We can use labels to track individual custom actions.