### PR TITLE
Lowers the max_history for TEDPolicy

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,6 +42,6 @@ policies:
    - name: RulePolicy
      core_fallback_threshold: 0.4
    - name: TEDPolicy
-     max_history: 17
+     max_history: 5
      epochs: 100
      constrain_similarities: true


### PR DESCRIPTION
 - This was initially increased due to some issues with the UnexpecTED policy. Since it was removed we can lower these values