### PR TITLE
Make rasa respect API_PORT when set

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import signal
+import sys
 
 from prometheus_client import start_http_server
 from threading import Event
@@ -34,6 +35,10 @@ def main():
 
     if config.PROMETHEUS == "True":
         start_prometheus()
+
+    # Use API_PORT when set
+    if config.API_PORT:
+        sys.argv.extend(["--port", str(config.API_PORT)])
 
     rasa_main()
 

--- a/common/config.py
+++ b/common/config.py
@@ -80,4 +80,5 @@ else:
     LOG_GROUP = os.getenv("LOG_GROUP", "platform-dev")
     # Metrics
     PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", 9000))
-    API_PORT = int(os.getenv("API_PORT", 5005))
+
+    API_PORT = int(os.getenv("API_PORT")) if os.getenv("API_PORT") else None


### PR DESCRIPTION
Rasa was not respecting the `API_PORT` environment variable. This is problematic since clowder wants us to route all api traffic via `cfg.publicPort`.

The only way I could make rasa use the `API_PORT` is by injecting the cli param, `--port`, before `rasa_main` call.

Interestingly, if we inject the cli param without the `if config.API_PORT` part, other rasa commands such as `validate` `train` etc. fails as they don't allow extra cli params.