### PR TITLE
Use private port for actions server

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -66,6 +66,7 @@ if os.getenv("ACG_CONFIG"):
     # Metrics
     PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", cfg.metricsPort))
     API_PORT = int(os.getenv("API_PORT", cfg.publicPort))
+    ACTIONS_PORT = int(os.getenv("ACTIONS_PORT", cfg.privatePort))
     # Database
     os.environ["DB_HOST"] = cfg.database.hostname
     os.environ["DB_PORT"] = str(cfg.database.port)
@@ -82,3 +83,4 @@ else:
     PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", 9000))
 
     API_PORT = int(os.getenv("API_PORT")) if os.getenv("API_PORT") else None
+    ACTIONS_PORT = int(os.getenv("ACTIONS_PORT")) if os.getenv("ACTIONS_PORT") else None

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -68,7 +68,7 @@ objects:
     - name: actions
       minReplicas: ${{MIN_REPLICAS}}
       webServices:
-        public:
+        private:
           enabled: true
         metrics:
           enabled: true
@@ -111,22 +111,6 @@ objects:
             cpu: 100m
             memory: 128Mi
 
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: actions-server
-    labels:
-      app: virtual-assistant
-      component: virtual-assistant-actions
-  spec:
-    selector:
-      pod: virtual-assistant-actions
-    ports:
-    - name: tcp-actions
-      protocol: TCP
-      port: 5055
-      targetPort: 5055
-
 parameters:
 - description: Minimum number of replicas required
   name: MIN_REPLICAS
@@ -157,4 +141,4 @@ parameters:
   value: "True"
 - description: Actions endpoint url
   name: ACTIONS_ENDPOINT_URL
-  value: http://actions-server:5055/webhook
+  value: http://virtual-assistant-actions:10000/webhook

--- a/run_actions.py
+++ b/run_actions.py
@@ -1,4 +1,5 @@
 import signal
+import sys
 
 from prometheus_client import start_http_server
 from threading import Event
@@ -34,6 +35,10 @@ def main():
 
     if config.PROMETHEUS == "True":
         start_prometheus()
+
+    # Use ACTIONS_PORT when set
+    if config.ACTIONS_PORT:
+        sys.argv.extend(["--port", str(config.ACTIONS_PORT)])
 
     rasa_sdk_main()
 


### PR DESCRIPTION
The reason the api server wasn't able to talk with the actions server is because the actions pods weren't getting selected correctly.

Update: Using this PR to get rid of the custom service, and instead use the private port config given to us by clowder