### PR TITLE
Adding CONSOLEDOT_BASE_URL to the deploy file

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -103,6 +103,8 @@ objects:
             value: ${TRACKER_STORE_TYPE}
           - name: PROMETHEUS
             value: ${PROMETHEUS}
+          - name: CONSOLEDOT_BASE_URL
+            value: ${CONSOLEDOT_BASE_URL}
         resources:
           limits:
             cpu: 250m
@@ -142,3 +144,7 @@ parameters:
 - description: Actions endpoint url
   name: ACTIONS_ENDPOINT_URL
   value: http://virtual-assistant-actions:10000/webhook
+- description: ConsoleDot base url
+  name: CONSOLEDOT_BASE_URL
+  value: https://console.redhat.com
+


### PR DESCRIPTION
Requests to other console APIs are failing, probably because this is not set.