### PR TITLE
Redis Lock Store - inMemoryDb flag

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -14,7 +14,8 @@ objects:
       - advisor-backend
       - notifications-gw
       - vulnerability-engine
-
+    
+    inMemoryDb: true
     database:
       name: virtual-assistant
       version: 12


### PR DESCRIPTION
Last time this crashed the clowdapp, but I think I have named the resource in app interface correctly now. 

After this gets in, we need to remove the LOCK_STORE_TYPE option in app interface