### PR TITLE
Wording fixes

### DIFF
--- a/actions/closing_actions.py
+++ b/actions/closing_actions.py
@@ -91,7 +91,6 @@ class ExecuteFormClosing(Action):
                 f"Should send the following feedback:{tracker.get_slot('closing_feedback')}"
             )
 
-
         dispatcher.utter_message(response="utter_closing_finally")
         return [
             SlotSet(key, None)


### PR DESCRIPTION
- Remove the gerunds in the buttons.
- Let's do a different message for yes or no in the closing intent.