### PR TITLE
Skip reading the intent and processing it while in the closing form

### DIFF
--- a/actions/closing_actions.py
+++ b/actions/closing_actions.py
@@ -11,6 +11,20 @@ class ValidateFormClosing(FormValidationAction):
     def name(self) -> Text:
         return "validate_form_closing"
 
+    @staticmethod
+    def extract_closing_got_help(
+        dispatcher: CollectingDispatcher, tracker: Tracker, domain: DomainDict
+    ) -> Dict[Text, Any]:
+        dispatcher.utter_message(response="utter_core_unknown_input")
+        return {"closing_got_help": tracker.slots.get("closing_got_help")}
+
+    @staticmethod
+    def extract_closing_leave_feedback(
+        dispatcher: CollectingDispatcher, tracker: Tracker, domain: DomainDict
+    ) -> Dict[Text, Any]:
+        dispatcher.utter_message(response="utter_core_unknown_input")
+        return {"closing_leave_feedback": tracker.slots.get("closing_leave_feedback")}
+
     async def should_ask_closing_feedback(self, dispatcher, tracker, domain):
         requested_slot = tracker.get_slot("requested_slot")
 

--- a/data/domain.yml
+++ b/data/domain.yml
@@ -81,6 +81,9 @@ responses:
     - text: "I'm sorry. I didn't understand that. Could you try to rephrase your question?"
     - text: "Sorry I didn't get that. Can you rephrase?"
     - text: 'I don''t understand. Say "I need help" for information on what I can do.'
+  utter_core_unknown_input:
+    - text: >
+        I'm sorry. I did not understand that answer. Could you try again?
   utter_planned_features:
     - text: "I haven't been programmed to do that yet. I'm still learning!"
     - text: "I'm working on that feature. Check for it again later."


### PR DESCRIPTION
 Instead tell the user that we did not understood and try again
 In the future we could have a way to break out of the form