### PR TITLE
RHCLOUD-28573 Send browser the "feedback" command to sprocess the feedback

### DIFF
--- a/actions/closing_actions.py
+++ b/actions/closing_actions.py
@@ -153,7 +153,7 @@ class ExecuteFormClosing(Action):
             user_got_help_section = "* Because of the feedback flow, the user was not asked if the conversation was helpful."
             if closing_skip_got_help is False:
                 user_got_help_section = (
-                    f"User's got help from the assistant? {closing_got_help}"
+                    f"Did the user get help from the assistant? {closing_got_help}"
                 )
 
             dispatcher.utter_message(


### PR DESCRIPTION
Apparently we don't have access to the feedback API from the backend, instead we are going to rely on the frontend to store the feedback.

Weakly depends on https://github.com/RedHatInsights/astro-virtual-assistant-frontend/pull/83
(i.e. it won't crash if the other code is not available)