### PR TITLE
RHCLOUD-29937 Bump the header request size

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -64,6 +64,8 @@ objects:
             value: ${PROMETHEUS}
           - name: ACTIONS_ENDPOINT_URL
             value: ${ACTIONS_ENDPOINT_URL}
+          - name: SANIC_REQUEST_MAX_HEADER_SIZE
+            value: ${SERVER_REQUEST_MAX_HEADER_SIZE}
         resources:
           limits:
             cpu: 500m
@@ -157,4 +159,6 @@ parameters:
 - description: ConsoleDot base url
   name: CONSOLEDOT_BASE_URL
   value: https://console.redhat.com
-
+- description: Server's max allowed header size
+  name: SERVER_REQUEST_MAX_HEADER_SIZE
+  value: "20000"


### PR DESCRIPTION
 It was using the default 1]  8192
 Now using what quarkus has set as default [2]

Also fixes [RHCLOUD-29808](https://issues.redhat.com/browse/RHCLOUD-29808)

[1] https://sanic.dev/en/guide/deployment/configuration.html#builtin-values
[2] https://quarkus.io/guides/all-config#quarkus-vertx-http_quarkus.http.limits.max-header-size