### PR TITLE
[RHCLOUD-29468] Use the dedicated health endpoint for actions server in probes

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -86,8 +86,8 @@ objects:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: 9000
+            path: /health
+            port: 10000
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -96,8 +96,8 @@ objects:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /metrics
-            port: 9000
+            path: /health
+            port: 10000
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 10


### PR DESCRIPTION
Funny story... the actions server already provides a health endpoint out of the box! 
[Here is the source](https://github.com/RasaHQ/rasa-sdk/blob/9c2691ed17d7eff7c89cceb0d6299594820ed633/rasa_sdk/endpoint.py#L85)
Verified this locally and on ephemeral :+1: 