### PR TITLE
Tweak config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,5 +47,5 @@ policies:
    - name: TEDPolicy
      max_history: 5
      epochs: 100
-     learning_rate: 0.005
+     learning_rate: 0.01
      constrain_similarities: true


### PR DESCRIPTION
 - Lower FallbackClassifier threshold

Had some tests identifying some intents as `nlu_fallback` 