### PR TITLE
Did not record complaints

### DIFF
--- a/actions/closing_actions.py
+++ b/actions/closing_actions.py
@@ -237,4 +237,7 @@ class ActionClosingFeedbackTypeGeneral(Action):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
-        return [SlotSet("closing_feedback_type", "general")]
+        return [
+            SlotSet("closing_feedback_type", "general"),
+            SlotSet("closing_leave_feedback", True),
+        ]


### PR DESCRIPTION
It was never sending the complaint because of the condition in the execute function

```
if tracker.get_slot("closing_leave_feedback") is True:
```

https://issues.redhat.com/browse/RHCLOUD-29935