### PR TITLE
Setting internal port on wrong variable

### DIFF
--- a/common/config/app.py
+++ b/common/config/app.py
@@ -38,7 +38,7 @@ actions_port = _config(
     "ACTIONS_PORT", default=_config("PRIVATE_PORT", default=0), cast=int
 )
 internal_api_port = _config(
-    "INTERNAL_API_PORT", default=_config("INTERNAL_API_PORT", default=0), cast=int
+    "INTERNAL_API_PORT", default=_config("PRIVATE_PORT", default=0), cast=int
 )
 
 is_running_locally = _config("IS_RUNNING_LOCALLY", default=False, cast=bool)


### PR DESCRIPTION
from logs: ```MainThread INFO root - Using internal_api_port: --not-set-- (0)```