### PR TITLE
Fix for local/ephemeral error

### DIFF
--- a/internal/database/db.py
+++ b/internal/database/db.py
@@ -20,5 +20,5 @@ class DB:
             self.conn_args = {"sslrootcert": app.database_ca_path}
 
     def get_engine(self):
-        engine = create_engine(self.conn_str, connect_args=self.conn_args)
+        engine = create_engine(self.conn_str, connect_args=self.conn_args or {})
         return engine


### PR DESCRIPTION
Jason found an error earlier in ephemeral

```
Traceback (most recent call last):
  File "/home/jorringe/astro-virtual-assistant/run_internal.py", line 9, in <module>
    from internal.endpoints import start_internal_api
  File "/home/jorringe/astro-virtual-assistant/internal/endpoints.py", line 21, in <module>
    engine = db.get_engine()
  File "/home/jorringe/astro-virtual-assistant/internal/database/db.py", line 23, in get_engine
    engine = create_engine(self.conn_str, connect_args=self.conn_args)
  File "<string>", line 2, in create_engine
  File "/home/jorringe/.local/share/virtualenvs/astro-virtual-assistant-jyrOmUK2/lib/python3.9/site-packages/sqlalchemy/util/deprecations.py", line 281, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/home/jorringe/.local/share/virtualenvs/astro-virtual-assistant-jyrOmUK2/lib/python3.9/site-packages/sqlalchemy/engine/create.py", line 618, in create_engine
    cparams.update(pop_kwarg("connect_args", {}))
TypeError: 'NoneType' object is not iterable
```

happens in local to, just because that self.conn_args is none