### PR TITLE
Fix post action of google sheet workflow

### DIFF
--- a/.github/workflows/upload-intents-google-sheet.yml
+++ b/.github/workflows/upload-intents-google-sheet.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-          cache: 'pipenv'
+          cache: 'pip'
       - run: pip install gspread google pyyaml
       - run: python scripts/dump_data.py > intents.csv
       - run: python scripts/update_google_sheet.py


### PR DESCRIPTION
 - Sets cache to pip as we are not using pipenv in this job