### PR TITLE
RHCLOUD-31034 Disable Rasa's API

### DIFF
--- a/docker/Dockerfile.astro-virtual-assistant-rasa
+++ b/docker/Dockerfile.astro-virtual-assistant-rasa
@@ -56,4 +56,4 @@ RUN rm -r .rasa
 
 USER 1001
 
-ENTRYPOINT ["python", "app.py", "run", "--endpoints", "endpoints.yml", "--enable-api"]
+ENTRYPOINT ["python", "app.py", "run", "--endpoints", "endpoints.yml"]


### PR DESCRIPTION
 - There is something forcing restarts on the pods, the commit that introduced this API seems to be the one. Checking if disabling this makes anything better