### PR TITLE
Moved to a less expensive operation

### DIFF
--- a/channels/console.py
+++ b/channels/console.py
@@ -116,10 +116,8 @@ class ConsoleInput(InputChannel):
             try:
                 # Use internal API instead of an HTTP request.
                 # Copied from https://github.com/RasaHQ/rasa/blob/68ce281aeec352876afb2baf74844e95b0c69ff4/rasa/server.py#L718-L741
-                tracker = await request.app.ctx.agent.processor.fetch_full_tracker_with_initial_session(
-                    sender_id, output_channel=CollectingOutputChannel()
-                )
 
+                tracker = await request.app.ctx.agent.processor.get_tracker(sender_id)
                 state = tracker.current_state(EventVerbosity.AFTER_RESTART)
                 is_first_visit = "name" not in state["latest_message"]["intent"]
 


### PR DESCRIPTION
 - Looks like fetch_full_tracker_with_initial_session is expensive and blocks the request for a long time, preventing other requests from taking place (eventually?)

Ran some benchmarks to confirm this:

Using fetch_full_tracker_with_initial_session:

```
[josejulio@fedora wrk]$ ./wrk -t12 -c400 -d30s  http://0.0.0.0:5005/api/virtual-assistant/v1/session/status -H "x-rh-identity: eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiJhY2NvdW50MTIzIiwib3JnX2lkIjoib3JnMTIzIiwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7ImlzX29yZ19hZG1pbiI6dHJ1ZSwgInVzZXJfaWQiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJhc3RybyJ9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" -H "Content-Type: application/json" Running 30s test @ http://0.0.0.0:5005/api/virtual-assistant/v1/session/status
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.43s   439.57ms   1.99s    65.66%
    Req/Sec     6.59      4.83    30.00     78.24%
  980 requests in 30.04s, 188.54KB read
  Socket errors: connect 0, read 48, write 0, timeout 782
Requests/sec:     32.62
Transfer/sec:      6.28KB
```

Using a simpler version `get_tracker` which looks like it gives us what we need:

```
[josejulio@fedora wrk]$ ./wrk -t12 -c400 -d30s  http://0.0.0.0:5005/api/virtual-assistant/v1/session/status -H "x-rh-identity: eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiJhY2NvdW50MTIzIiwib3JnX2lkIjoib3JnMTIzIiwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7ImlzX29yZ19hZG1pbiI6dHJ1ZSwgInVzZXJfaWQiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJhc3RybyJ9LCJpbnRlcm5hbCI6eyJvcmdfaWQiOiJvcmcxMjMifX19" -H "Content-Type: application/json" Running 30s test @ http://0.0.0.0:5005/api/virtual-assistant/v1/session/status
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    91.57ms   81.27ms   1.99s    98.78%
    Req/Sec   320.46    180.68     1.35k    72.12%
  104588 requests in 30.04s, 19.55MB read
  Socket errors: connect 0, read 0, write 0, timeout 259
Requests/sec:   3482.07
Transfer/sec:    666.49KB
```

32.62 requests/sec vs 3482.07 requests/sec

I also tested the health check vs spamming the the first visit endpoint
- With the expensive call it never refreshed while the test was running
- The other call allowed it to run