### PR TITLE
Revert "bumping up memory req-limit by a factor of 2 (#296)"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -72,10 +72,10 @@ objects:
         resources:
           limits:
             cpu: 500m
-            memory: 4Gi
+            memory: 2Gi
           requests:
             cpu: 250m
-            memory: 2Gi
+            memory: 1Gi
 
     - name: actions
       minReplicas: ${{MIN_REPLICAS}}


### PR DESCRIPTION
This reverts commit 42db7640577774750b5754490ba238ea3cd06460.

Reverting because it looks like our other environment is stable with these values and they did not contribute to the issue we were having