### PR TITLE
Image Builder - properly check errors dict

### DIFF
--- a/actions/insights/image_builder_actions.py
+++ b/actions/insights/image_builder_actions.py
@@ -249,7 +249,9 @@ class ValidateFormImageBuilderCustomContent(FormValidationAction):
         if "errors" in result:
             errors = result["errors"]
 
-        if status == 400 and any("already belongs" in error["detail"] for error in errors):
+        if status == 400 and any(
+            "already belongs" in error["detail"] for error in errors
+        ):
             dispatcher.utter_message(
                 response="utter_image_builder_custom_content_epel_already_enabled",
                 version=version,


### PR DESCRIPTION
I didn't realize that content-sources sent back an array of errors.
- Removed unnecessary logging.

https://issues.redhat.com/browse/RHCLOUD-31270