### PR TITLE
Subscriptions nlu band-aid

### DIFF
--- a/data/insights/subscriptions/nlu.yml
+++ b/data/insights/subscriptions/nlu.yml
@@ -77,6 +77,11 @@ nlu:
       - How many subscriptions that are expiring soon?
       - what information do you have for my subs?
       - information on my subscriptions
+      - View my subscriptions
+      - view my organizations subscriptions
+      - show me my subscriptions
+      - Where can I see my subscriptions?
+      - Can you show me my subscriptions?
 
   - intent: intent_subscriptions_redirect
     examples: |
@@ -96,3 +101,5 @@ nlu:
       - View subscription documentation on the redhat portal
       - View subscription documentation on the red-hat portal
       - view subscription documentation on the portal
+      - view documentation on the red hat portal
+      - view subs documentation on the red hat portal


### PR DESCRIPTION
The capabilities flow has these phrases as options, but the nlu didn't have them.

The documentation message "View documentation on the Red Hat Portal" is too generic of a phrase. If we really wanted the user to match properly, maybe we should lock them in a form?