### PR TITLE
Closing reset slots when not completed

### DIFF
--- a/actions/closing_actions.py
+++ b/actions/closing_actions.py
@@ -74,21 +74,27 @@ class ValidateFormClosing(FormValidationAction):
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
         # feedback_type is set by the feedback flow
-        if (
-            await form_action_is_starting(self, dispatcher, tracker, domain)
-            and tracker.get_slot("closing_feedback_type") is None
-        ):
-            flow_started_count(Flow.CLOSING)
-            return [
-                SlotSet(key, None)
-                for key in [
-                    "closing_got_help",
-                    "closing_leave_feedback",
-                    "closing_feedback",
-                    "closing_skip_got_help",
-                    "closing_feedback_type",
+        if await form_action_is_starting(self, dispatcher, tracker, domain):
+            if tracker.get_slot("closing_feedback_type") is None:
+                flow_started_count(Flow.CLOSING)
+                return [
+                    SlotSet(key, None)
+                    for key in [
+                        "closing_got_help",
+                        "closing_leave_feedback",
+                        "closing_feedback",
+                        "closing_skip_got_help",
+                        "closing_feedback_type",
+                    ]
                 ]
-            ]
+            else:
+                return [
+                    SlotSet(key, None)
+                    for key in [
+                        "closing_got_help",
+                        "closing_feedback",
+                    ]
+                ]
 
         requested_slot = tracker.get_slot("requested_slot")
 

--- a/actions/closing_actions.py
+++ b/actions/closing_actions.py
@@ -73,11 +73,22 @@ class ValidateFormClosing(FormValidationAction):
     async def run(
         self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
     ) -> List[Dict[Text, Any]]:
+        # feedback_type is set by the feedback flow
         if (
             await form_action_is_starting(self, dispatcher, tracker, domain)
             and tracker.get_slot("closing_feedback_type") is None
         ):
             flow_started_count(Flow.CLOSING)
+            return [
+                SlotSet(key, None)
+                for key in [
+                    "closing_got_help",
+                    "closing_leave_feedback",
+                    "closing_feedback",
+                    "closing_skip_got_help",
+                    "closing_feedback_type",
+                ]
+            ]
 
         requested_slot = tracker.get_slot("requested_slot")
 


### PR DESCRIPTION
This won't take care of all cases (if someone leaves from the feedback flow without finishing and then goes back to the closing flow, it would skip the thumbs up/down question.

Fixes case where the user goes to the closing, stops at the leave feedback question, starts again.

```Your input ->  advisor
? Are you looking for help with Advisor for OpenShift or RHEL? 2: RHEL (rhel)
? What type of recommendation are you looking for? 1: Performance (performance)
Here are your top performance recommendations from Advisor.
 1. [Interfaces dropping packets when ring buffer is fill up](/insights/advisor/recommendations/rx_packet_drops|RX_PACKET_DROPS)
 2. [VMware guest performance decreases and shows as vulnerable to RETBleed due to a known kernel bug](/insights/advisor/recommendations/vmware_guest_retbleed_vulnerabilities|VMWARE_GUEST_RETBLEED_VULNERABILITIES)
 3. [System performance degrades when adding the "spectre_v2=retpoline" kernel parameter to Intel Cascade Lake system](/insights/advisor/recommendations/cascade_cpu_no_need_spectre_v2|PERFORMANCE_DEGRADATION_CASCADE_LAKE_SPECTRE_V2)
You can see additional recommendations on the [Advisor dashboard](/insights/advisor/recommendations?category=4&impacting=true&rule_status=enabled&limit=20&offset=0).
How would you rate our conversation?
Custom json:
{
  "type": "command",
  "command": "thumbs"
}
Your input ->  yes
Great!
? Would you like to leave any additional feedback? Type out your own message...
Your input ->  advisor
? Are you looking for help with Advisor for OpenShift or RHEL? 2: RHEL (rhel)
? What type of recommendation are you looking for? 1: Performance (performance)
Here are your top performance recommendations from Advisor.
 1. [Interfaces dropping packets when ring buffer is fill up](/insights/advisor/recommendations/rx_packet_drops|RX_PACKET_DROPS)
 2. [VMware guest performance decreases and shows as vulnerable to RETBleed due to a known kernel bug](/insights/advisor/recommendations/vmware_guest_retbleed_vulnerabilities|VMWARE_GUEST_RETBLEED_VULNERABILITIES)
 3. [System performance degrades when adding the "spectre_v2=retpoline" kernel parameter to Intel Cascade Lake system](/insights/advisor/recommendations/cascade_cpu_no_need_spectre_v2|PERFORMANCE_DEGRADATION_CASCADE_LAKE_SPECTRE_V2)
You can see additional recommendations on the [Advisor dashboard](/insights/advisor/recommendations?category=4&impacting=true&rule_status=enabled&limit=20&offset=0).
How would you rate our conversation?
Custom json:
{
  "type": "command",
  "command": "thumbs"
}
Your input ->  yes
Great!
? Would you like to submit any feedback? 1: Yes (/intent_core_yes)
You can type in your feedback below and I'll share it with my team.
Your input ->  this is a test
```