### PR TITLE
Changed red hat not to refer to rhel

### DIFF
--- a/actions/insights/advisor_actions.py
+++ b/actions/insights/advisor_actions.py
@@ -45,7 +45,7 @@ advisor_categories = FuzzySlotMatch(
 advisor_system = FuzzySlotMatch(
     "insights_advisor_system_kind",
     [
-        FuzzySlotMatchOption("rhel", ["rhel", "redhat", "red-hat", "red hat"]),
+        FuzzySlotMatchOption("rhel", ["rhel", "enterprise", "linux"]),
         FuzzySlotMatchOption("openshift"),
     ],
 )

--- a/data/insights/advisor/nlu.yml
+++ b/data/insights/advisor/nlu.yml
@@ -42,3 +42,5 @@ nlu:
       - new rhel advisor
       - Any performance suggestions from Advisor?
       - new suggestions from Advisor?
+      - tell me advisor recommendations for red hat enterprise linux
+      - linux recommendations from advisor


### PR DESCRIPTION
Since RHEL or Openshift could refer to red hat

Like if a user says "Red Hat Openshift" what happens?