### PR TITLE
Fail fast on dependencies env option

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -36,3 +36,6 @@ CONSOLEDOT_BASE_URL=https://console.redhat.com
 # CONSOLEDOT_BASE_URL=https://console.stage.redhat.com
 
 SERVER_REQUEST_MAX_HEADER_SIZE=20000
+
+# for ephemeral environment, needs to be false
+FAIL_FAST_ON_DEPENDENCIES=true

--- a/common/config/app.py
+++ b/common/config/app.py
@@ -52,7 +52,9 @@ internal_api_port = _config(
 
 is_running_locally = _config("IS_RUNNING_LOCALLY", default=False, cast=bool)
 __optional_when_locally = __undefined if is_running_locally is False else None
-fail_fast_on_dependencies = _config("FAIL_FAST_ON_DEPENDENCIES", default=True, cast=bool)
+fail_fast_on_dependencies = _config(
+    "FAIL_FAST_ON_DEPENDENCIES", default=True, cast=bool
+)
 
 __endpoint_default = __undefined
 if is_running_locally:

--- a/common/config/app.py
+++ b/common/config/app.py
@@ -17,7 +17,7 @@ dev_sso_refresh_token_url = _config(
     default=None,
 )
 
-not_set_base_url = "https://not-set.com"
+not_set_base_url = "https://example.com"
 console_dot_base_url = _config(
     "CONSOLEDOT_BASE_URL", default="https://console.redhat.com"
 )

--- a/common/config/app.py
+++ b/common/config/app.py
@@ -17,6 +17,7 @@ dev_sso_refresh_token_url = _config(
     default=None,
 )
 
+not_set_base_url = "https://not-set.com"
 console_dot_base_url = _config(
     "CONSOLEDOT_BASE_URL", default="https://console.redhat.com"
 )
@@ -51,9 +52,14 @@ internal_api_port = _config(
 
 is_running_locally = _config("IS_RUNNING_LOCALLY", default=False, cast=bool)
 __optional_when_locally = __undefined if is_running_locally is False else None
-__endpoint_default = (
-    __undefined if is_running_locally is False else console_dot_base_url
-)
+fail_fast_on_dependencies = _config("FAIL_FAST_ON_DEPENDENCIES", default=True, cast=bool)
+
+__endpoint_default = __undefined
+if is_running_locally:
+    __endpoint_default = console_dot_base_url
+elif fail_fast_on_dependencies is False:
+    __endpoint_default = not_set_base_url
+    print(f"Dependencies are not required, using {__endpoint_default} as default.")
 
 environment_name = _config("ENVIRONMENT_NAME", default="stage", cast=str)
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -65,6 +65,8 @@ objects:
             value: ${CLOWDER_ENABLED}
           - name: LOG_LEVEL
             value: ${LOG_LEVEL}
+          - name: FAIL_FAST_ON_DEPENDENCIES
+            value: ${FAIL_FAST_ON_DEPENDENCIES}
           - name: TRACKER_STORE_TYPE
             value: ${TRACKER_STORE_TYPE}
           - name: LOCK_STORE_TYPE
@@ -118,6 +120,8 @@ objects:
             value: ${CLOWDER_ENABLED}
           - name: LOG_LEVEL
             value: ${LOG_LEVEL}
+          - name: FAIL_FAST_ON_DEPENDENCIES
+            value: ${FAIL_FAST_ON_DEPENDENCIES}
           - name: TRACKER_STORE_TYPE
             value: ${TRACKER_STORE_TYPE}
           - name: PROMETHEUS
@@ -207,6 +211,8 @@ parameters:
   value: "1"
 - name: LOG_LEVEL
   value: INFO
+- name: FAIL_FAST_ON_DEPENDENCIES
+  value: "true"
 - description: Determines Clowder deployment
   name: CLOWDER_ENABLED
   value: "true"


### PR DESCRIPTION
Adding a fail fast variable. In ephemeral, if we set it to false it should help those dependency issues.

Defaulting the value to true in the clowdapp, so we shouldn't have to add the value to app-interface for stage and prod.