### PR TITLE
Adding fail fast var to internal API

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -175,6 +175,8 @@ objects:
             value: ${CLOWDER_ENABLED}
           - name: LOG_LEVEL
             value: ${LOG_LEVEL}
+          - name: FAIL_FAST_ON_DEPENDENCIES
+            value: ${FAIL_FAST_ON_DEPENDENCIES}
           - name: TRACKER_STORE_TYPE
             value: ${TRACKER_STORE_TYPE}
           - name: PROMETHEUS


### PR DESCRIPTION
I didn't think the internal API would need this fail fast var, but for the internal API to spin up without dependencies it does!