### PR TITLE
Notifications bundle and muted types param

### DIFF
--- a/actions/platform/notifications/notifications_actions.py
+++ b/actions/platform/notifications/notifications_actions.py
@@ -330,7 +330,8 @@ class ValidateFormNotifications(FormValidationAction):
                         bundle=bundle["display_name"],
                     )
                     dispatcher.utter_message(
-                        response="utter_notifications_edit_events_none_2"
+                        response="utter_notifications_edit_events_none_2",
+                        bundle=bundle["name"],
                     )
                     events.append(SlotSet("requested_slot", None))
                     return events
@@ -429,12 +430,15 @@ class ValidateFormNotifications(FormValidationAction):
             bundle = tracker.get_slot(NOTIF_BUNDLE)
             if option == "attach":
                 dispatcher.utter_message(
-                    response="utter_notifications_edit_new_group", event=event["name"]
+                    response="utter_notifications_edit_new_group",
+                    event=event["name"],
+                    bundle=bundle["name"],
                 )
             elif option == "create":
                 dispatcher.utter_message(
                     response="utter_notifications_edit_create_group",
                     event=event["display_name"],
+                    bundle=bundle["name"],
                 )
             elif option == "remove":
                 response, result = await get_behavior_groups(tracker, bundle["id"])

--- a/actions/platform/notifications/notifications_actions.py
+++ b/actions/platform/notifications/notifications_actions.py
@@ -315,11 +315,9 @@ class ValidateFormNotifications(FormValidationAction):
                 dispatcher.utter_message(response="utter_notifications_learn_docs")
                 events.append(SlotSet("requested_slot", None))
             else:
-                has_notifications_available = None
-                if option == "manage preferences":
-                    has_notifications_available = True
+                exclude_muted_types = option == "manage preferences"
                 response, result = await get_available_events_by_bundle(
-                    tracker, bundle["id"], has_notifications_available
+                    tracker, bundle["id"], exclude_muted_types
                 )
                 if not response.ok or not result:
                     received_notifications_error(dispatcher, response, result)
@@ -586,18 +584,15 @@ async def get_available_bundles(tracker: Tracker):
 
 
 async def get_available_events_by_bundle(
-    tracker: Tracker, bundleId: str, has_notifications_available: Optional[bool] = None
+    tracker: Tracker, bundleId: str, exclude_muted_types: Optional[bool] = False
 ):
     params = {
         "limit": 20,
         "offset": 0,
         "sort_by": "application:ASC",
         "bundleId": bundleId,
+        "excludeMutedTypes": str(exclude_muted_types),
     }
-    # TODO: request this feature
-    if has_notifications_available:
-        # params["hasNotifications"] = True
-        pass
     return await send_console_request(
         "notifications",
         "/api/notifications/v1.0/notifications/eventTypes",

--- a/data/notifications/domain.yml
+++ b/data/notifications/domain.yml
@@ -163,7 +163,7 @@ responses:
   utter_notifications_edit_events_none_1:
     - text: "You don't have any active events for {bundle} yet."
   utter_notifications_edit_events_none_2:
-    - text: "Visit the [Notifications dashboard](/settings/notifications/configure-events) for more information."
+    - text: "Visit the [Notifications dashboard](/settings/notifications/configure-events?bundle={bundle}) for more information."
   utter_notifications_edit_events_mute_success:
     - text: "I have muted notifications for the {event} event."
   utter_notifications_edit_events_mute_error:
@@ -196,7 +196,7 @@ responses:
         type: command
         command: redirect
         params:
-          url: "{base_console_url}/settings/notifications/configure-events?name={event}"
+          url: "{base_console_url}/settings/notifications/configure-events?bundle={bundle}&name={event}"
   utter_notifications_edit_existing_group:
     - text: "Okay. The Notifications dashboard lets you attach and detach behavior groups to your events."
   utter_notifications_edit_no_groups:
@@ -214,7 +214,7 @@ responses:
         type: command
         command: redirect
         params:
-          url: "{base_console_url}/settings/notifications/configure-events"
+          url: "{base_console_url}/settings/notifications/configure-events?bundle={bundle}"
 
   # Troubleshoot notifications
   utter_notifications_troubleshoot_non_admin:


### PR DESCRIPTION
Since we added this, the UI now accepts bundle param.

excludeMutedTypes param isn't working like I expect it to (providing some types that I have muted), but it's fine to go ahead and add it I think.