### PR TITLE
Clearing Subs Usage slot

### DIFF
--- a/actions/insights/subscriptions_actions.py
+++ b/actions/insights/subscriptions_actions.py
@@ -142,6 +142,7 @@ class SubsProductUsage(FormValidationAction):
 
         return events
 
+
 class SubsProductUsageResetSlots(Action):
     def name(self) -> Text:
         return "action_subs_product_usage_reset_slots"

--- a/actions/insights/subscriptions_actions.py
+++ b/actions/insights/subscriptions_actions.py
@@ -2,7 +2,7 @@ from typing import Any, Text, Dict, List
 
 from rasa_sdk import Action, Tracker, FormValidationAction
 from rasa_sdk.executor import CollectingDispatcher
-from rasa_sdk.events import UserUtteranceReverted
+from rasa_sdk.events import UserUtteranceReverted, SlotSet
 from rasa_sdk.types import DomainDict
 
 from actions.slot_match import FuzzySlotMatch, FuzzySlotMatchOption, resolve_slot_match
@@ -141,3 +141,12 @@ class SubsProductUsage(FormValidationAction):
                 )
 
         return events
+
+class SubsProductUsageResetSlots(Action):
+    def name(self) -> Text:
+        return "action_subs_product_usage_reset_slots"
+
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict
+    ) -> List[Dict[Text, Any]]:
+        return [SlotSet(SUBS_PRODUCT_TYPE_SLOT, None)]

--- a/data/insights/subscriptions/domain.yml
+++ b/data/insights/subscriptions/domain.yml
@@ -27,6 +27,7 @@ slots:
 actions:
   - action_check_subscriptions
   - validate_form_subs_product_usage
+  - action_subs_product_usage_reset_slots
 
 forms:
   form_subs_product_usage:

--- a/data/insights/subscriptions/rules.yml
+++ b/data/insights/subscriptions/rules.yml
@@ -25,6 +25,7 @@ rules:
   - rule: Subscriptions Product Usage (SU5)
     steps:
       - intent: intent_subs_product_usage
+      - action: action_subs_product_usage_reset_slots
       - action: form_subs_product_usage
       - active_loop: form_subs_product_usage
 

--- a/tests/stories/insights/subscriptions/test_subscriptions_rules.yml
+++ b/tests/stories/insights/subscriptions/test_subscriptions_rules.yml
@@ -4,6 +4,7 @@ stories:
   - story: Subscriptions Product Usage (SU5)
     steps:
       - intent: intent_subs_product_usage
+      - action: action_subs_product_usage_reset_slots
       - action: form_subs_product_usage
       - active_loop: form_subs_product_usage
 


### PR DESCRIPTION
To fix:

```
Your input ->  subs usage
? Which product's usage are you looking for? 2: OpenShift (openshift)
You can monitor your OpenShift subscription usage on the [Subscription Usage Dashboard](https://console.redhat.com/subscriptions/usage/openshift). Usage information is available for both Annual and On-demand subscriptions.
How would you rate our conversation?
Custom json:
{
  "type": "command",
  "command": "thumbs"
}
Your input ->  SUBS USAGE
How would you rate our conversation?
Custom json:
{
  "type": "command",
  "command": "thumbs"
}
Your input ->
```
