### PR TITLE
Implement a basic internal watson extension api

### DIFF
--- a/common/config/app.py
+++ b/common/config/app.py
@@ -134,6 +134,11 @@ connector_api_base_url = _config(
 )
 connector_api_port = _config("CONNECTOR_API_PORT", default=5000)
 
+internal_watson_extension_base_url = _config(
+    "INTERNAL_WATSON_EXTENSION_BASE_URL", default="/internal/api/v1"
+)
+internal_watson_extension_port = _config("INTERNAL_WATSON_EXTENSION_PORT", default=5050)
+
 watson_api_url = _config("WATSON_API_URL", default=None)
 watson_api_key = _config("WATSON_API_KEY", default=None)
 watson_env_id = _config("WATSON_ENV_ID", default=None)

--- a/common/requests.py
+++ b/common/requests.py
@@ -94,3 +94,18 @@ async def send_console_request(
         if fetch_content:
             return bad_response, None
         return bad_response
+
+
+def send_console_request_watson(
+    app_name: str,
+    path: str,
+    method: str = "get",
+    headers: Optional[Header] = None,
+    fetch_content: bool = True,
+    **kwargs,
+) -> Any:
+    #TODO: this will be and implementation of send_console_request() without the Rasa tracker
+    if app_name == "cat_facts":
+        return  {"fact":"The first cat show was organized in 1871 in London. Cat shows later became a worldwide craze.","length":93}
+    else:
+        return {"app_name": app_name}

--- a/common/requests.py
+++ b/common/requests.py
@@ -104,8 +104,11 @@ def send_console_request_watson(
     fetch_content: bool = True,
     **kwargs,
 ) -> Any:
-    #TODO: this will be and implementation of send_console_request() without the Rasa tracker
+    # TODO: this will be and implementation of send_console_request() without the Rasa tracker
     if app_name == "cat_facts":
-        return  {"fact":"The first cat show was organized in 1871 in London. Cat shows later became a worldwide craze.","length":93}
+        return {
+            "fact": "The first cat show was organized in 1871 in London. Cat shows later became a worldwide craze.",
+            "length": 93,
+        }
     else:
         return {"app_name": app_name}

--- a/run_internal_watson_extension.py
+++ b/run_internal_watson_extension.py
@@ -1,0 +1,15 @@
+from flask import Flask
+import os
+from common.config import app
+
+from watson.internal_watson_extension.routes import api_blueprint
+
+api = Flask(__name__)
+
+base_url = app.internal_watson_extension_base_url
+api.register_blueprint(api_blueprint, url_prefix=base_url)
+
+if __name__ == "__main__":
+    port = int(app.internal_watson_extension_port)
+    print(f"Starting app at port {port} with base URL: {base_url}")
+    api.run(port=port)

--- a/watson/internal_watson_extension/functions.py
+++ b/watson/internal_watson_extension/functions.py
@@ -1,0 +1,14 @@
+from watson.internal_watson_extension import normalizers
+from common.config import app
+
+functions_map = {
+    "fun_cat_facts": {
+        "console_request_args": {
+                "app_name": 'cat_facts',
+                "path": '/get_facts',
+                "method": "get",
+                # app_name,path,method is required, but can contain a number of different variables here
+        },
+        "normalizer": normalizers.cat_facts_normalizer,
+    }
+}

--- a/watson/internal_watson_extension/functions.py
+++ b/watson/internal_watson_extension/functions.py
@@ -4,10 +4,10 @@ from common.config import app
 functions_map = {
     "fun_cat_facts": {
         "console_request_args": {
-                "app_name": 'cat_facts',
-                "path": '/get_facts',
-                "method": "get",
-                # app_name,path,method is required, but can contain a number of different variables here
+            "app_name": "cat_facts",
+            "path": "/get_facts",
+            "method": "get",
+            # app_name,path,method is required, but can contain a number of different variables here
         },
         "normalizer": normalizers.cat_facts_normalizer,
     }

--- a/watson/internal_watson_extension/normalizers.py
+++ b/watson/internal_watson_extension/normalizers.py
@@ -1,0 +1,5 @@
+# Sample normalizer to format data that will come in from console_request
+def cat_facts_normalizer(data):
+    cat_fact = data.get("fact")
+    return {"cat_fact": cat_fact}
+

--- a/watson/internal_watson_extension/normalizers.py
+++ b/watson/internal_watson_extension/normalizers.py
@@ -2,4 +2,3 @@
 def cat_facts_normalizer(data):
     cat_fact = data.get("fact")
     return {"cat_fact": cat_fact}
-

--- a/watson/internal_watson_extension/routes.py
+++ b/watson/internal_watson_extension/routes.py
@@ -1,0 +1,69 @@
+from flask import Blueprint, jsonify, request
+from pydantic import BaseModel, ValidationError
+from typing import Optional
+
+from watson.internal_watson_extension.functions import functions_map
+from common.requests import send_console_request_watson
+
+api_blueprint = Blueprint("internal_api", __name__)
+
+class ExecuteFunctionRequest(BaseModel):
+    session_id: str
+    function_name: str
+    metadata: Optional[dict] = None
+
+def run_function(request_session_id, function_name, functions_map):
+    if function_name not in functions_map:
+        raise ValueError(f"Function '{function_name}' not found in functions_map")
+
+    function_details = functions_map[function_name]
+    console_request_args = function_details.get("console_request_args", {})
+    normalizer = function_details.get("normalizer")
+
+    # Ensure the normalizer is a callable function
+    if not callable(normalizer):
+        raise ValueError(f"The normalizer for function '{function_name}' is not callable")
+
+    #TODO: Handle auth + Redis interaction here to obtain the necessry headers
+
+    try:
+
+        #TODO: update this with a new function that can handle auth
+        data = send_console_request_watson(**console_request_args)
+
+        # Normalize the data using the provided normalizer function
+        normalized_data = normalizer(data)
+
+        return normalized_data
+    except Exception as e:
+        # Catch all other exceptions
+        raise Exception(f"An unexpected error occurred: {e}")
+
+
+@api_blueprint.route("/", methods=["GET"])
+def health():
+    return jsonify({"status": "Ok"})
+
+
+@api_blueprint.route("/execute_function", methods=["POST"])
+def execute_function():
+    data = request.get_json()
+
+    if not data:
+        return jsonify({"error": "No request body"}), 400
+
+    try:
+        validated_data = ExecuteFunctionRequest(**data)
+    except ValidationError as e:
+        return jsonify({"errors": e.errors()}), 400
+
+    function_name = validated_data.function_name
+    request_session_id = validated_data.session_id
+
+    try:
+        function_response = run_function(request_session_id, function_name, functions_map)
+    except Exception as e:
+        print(e)
+        return jsonify({"message": "internal error encountered while executing function"}), 500
+
+    return jsonify(function_response), 200

--- a/watson/internal_watson_extension/routes.py
+++ b/watson/internal_watson_extension/routes.py
@@ -7,10 +7,12 @@ from common.requests import send_console_request_watson
 
 api_blueprint = Blueprint("internal_api", __name__)
 
+
 class ExecuteFunctionRequest(BaseModel):
     session_id: str
     function_name: str
     metadata: Optional[dict] = None
+
 
 def run_function(request_session_id, function_name, functions_map):
     if function_name not in functions_map:
@@ -22,13 +24,15 @@ def run_function(request_session_id, function_name, functions_map):
 
     # Ensure the normalizer is a callable function
     if not callable(normalizer):
-        raise ValueError(f"The normalizer for function '{function_name}' is not callable")
+        raise ValueError(
+            f"The normalizer for function '{function_name}' is not callable"
+        )
 
-    #TODO: Handle auth + Redis interaction here to obtain the necessry headers
+    # TODO: Handle auth + Redis interaction here to obtain the necessry headers
 
     try:
 
-        #TODO: update this with a new function that can handle auth
+        # TODO: update this with a new function that can handle auth
         data = send_console_request_watson(**console_request_args)
 
         # Normalize the data using the provided normalizer function
@@ -61,9 +65,14 @@ def execute_function():
     request_session_id = validated_data.session_id
 
     try:
-        function_response = run_function(request_session_id, function_name, functions_map)
+        function_response = run_function(
+            request_session_id, function_name, functions_map
+        )
     except Exception as e:
         print(e)
-        return jsonify({"message": "internal error encountered while executing function"}), 500
+        return (
+            jsonify({"message": "internal error encountered while executing function"}),
+            500,
+        )
 
     return jsonify(function_response), 200


### PR DESCRIPTION
Run using:
`IS_RUNNING_LOCALLY="true" pipenv run python run_internal_watson_extension.py`

Then:
```
POST on http://127.0.0.1:5050/internal/api/v1/execute_function

Header:
Content-Type: application/json

Body:
{
    "session_id": "1234",
    "function_name": "fun_cat_facts"
}
```


We will tackle the following in future PRs:
1. Handle auth + Redis interaction to obtain the necessry headers before sending console request 
2. Implementation of `send_console_request_watson()`, which is `send_console_request()` without the Rasa tracker
3. Switch to `quant` from `flask`
