### PR TITLE
Use quart instead of flask in virtual-assistant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ include scripts/make/Makefile.variables.mk
 include scripts/make/Makefile.test.mk
 include scripts/make/Makefile.lint.mk
 
+export PIPENV_IGNORE_VIRTUALENVS=1
+
 # install and train the project
 install: install-root
 	make install -C services/virtual-assistant

--- a/libs/common/src/common/auth.py
+++ b/libs/common/src/common/auth.py
@@ -4,7 +4,7 @@ import requests
 from common.config import app
 from .header import Header
 
-from flask import request, jsonify
+from quart import request, jsonify
 import base64
 import functools
 import json
@@ -89,11 +89,11 @@ def check_identity(identity_header):
 
 def require_identity_header(func):
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    async def wrapper(*args, **kwargs):
         identity_header = request.headers.get("x-rh-identity")
         if not identity_header or not check_identity(identity_header):
             return jsonify(message="Invalid x-rh-identity"), 401
-        return func(*args, **kwargs)
+        return await func(*args, **kwargs)
 
     return wrapper
 

--- a/libs/common/src/pyproject.toml
+++ b/libs/common/src/pyproject.toml
@@ -4,5 +4,6 @@ dynamic = ["version"]
 # Keep in sync with Pipfile
 dependencies = [
     "python-decouple",
-    "app_common_python"
+    "app_common_python",
+    "quart"
 ]

--- a/services/virtual-assistant/Pipfile
+++ b/services/virtual-assistant/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-flask = ">=3.0.0"
+"quart-schema[pydantic]" = "*"
 pydantic = ">=2.10.5"
 ibm-watson = ">=9.0.0"
 ibm-cloud-sdk-core = "3.22.1"
@@ -12,3 +12,5 @@ common = {editable=true, path="../../libs/common/src"}
 
 [requires]
 python_version = "3.12"
+
+[dev-packages]

--- a/services/virtual-assistant/Pipfile.lock
+++ b/services/virtual-assistant/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "71332aa787d0903aae839b94ce74718e03fe4c91733a410083278a255b12f12a"
+            "sha256": "132bc48c2758279a046fc7a9f10ee42b589b94884d9c0a2fc142224f0803e651"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "aiofiles": {
+            "hashes": [
+                "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c",
+                "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.1.0"
+        },
         "annotated-types": {
             "hashes": [
                 "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53",
@@ -162,9 +170,48 @@
                 "sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac",
                 "sha256:d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==3.1.0"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+                "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.14.0"
+        },
+        "h2": {
+            "hashes": [
+                "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d",
+                "sha256:a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==4.1.0"
+        },
+        "hpack": {
+            "hashes": [
+                "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496",
+                "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.1.0"
+        },
+        "hypercorn": {
+            "hashes": [
+                "sha256:059215dec34537f9d40a69258d323f56344805efb462959e727152b0aa504547",
+                "sha256:1b37802ee3ac52d2d85270700d565787ab16cf19e1462ccfa9f089ca17574165"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.17.3"
+        },
+        "hyperframe": {
+            "hashes": [
+                "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5",
+                "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==6.1.0"
         },
         "ibm-cloud-sdk-core": {
             "hashes": [
@@ -272,6 +319,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==3.0.2"
+        },
+        "priority": {
+            "hashes": [
+                "sha256:6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa",
+                "sha256:c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==2.0.0"
         },
         "pydantic": {
             "hashes": [
@@ -388,6 +443,13 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.27.2"
         },
+        "pyhumps": {
+            "hashes": [
+                "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6",
+                "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3"
+            ],
+            "version": "==3.8.0"
+        },
         "pyjwt": {
             "hashes": [
                 "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953",
@@ -410,6 +472,25 @@
                 "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66"
             ],
             "version": "==3.8"
+        },
+        "quart": {
+            "hashes": [
+                "sha256:003c08f551746710acb757de49d9b768986fd431517d0eb127380b656b98b8f1",
+                "sha256:08793c206ff832483586f5ae47018c7e40bdd75d886fee3fabbdaa70c2cf505d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.20.0"
+        },
+        "quart-schema": {
+            "extras": [
+                "pydantic"
+            ],
+            "hashes": [
+                "sha256:57b8f7d2f8cc5bcbf6b2200ed17f870fc26811c5d0ac5c6a02352644ab068129",
+                "sha256:5edcd18adb223c9d0f234688238882884fb09a4ee52fb29b50928821adbb7064"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.21.0"
         },
         "requests": {
             "hashes": [
@@ -458,6 +539,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==3.1.3"
+        },
+        "wsproto": {
+            "hashes": [
+                "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065",
+                "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==1.2.0"
         }
     },
     "develop": {}

--- a/services/virtual-assistant/src/virtual-assistant/routes.py
+++ b/services/virtual-assistant/src/virtual-assistant/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from quart import Blueprint, jsonify, request
 from pydantic import ValidationError
 from ibm_watson import AssistantV2
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
@@ -20,13 +20,13 @@ def get_watson_assistant():
 
 
 @api_blueprint.route("/", methods=["GET"])
-def health():
+async def health():
     return jsonify({"status": "Ok"})
 
 
 @api_blueprint.route("/talk", methods=["POST"])
 @require_identity_header
-def talk():
+async def talk():
     data = request.get_json()
     identity = request.headers.get("x-rh-identity")
     org_id = get_org_id_from_identity(identity)

--- a/services/virtual-assistant/src/virtual-assistant/run.py
+++ b/services/virtual-assistant/src/virtual-assistant/run.py
@@ -1,13 +1,15 @@
-from flask import Flask
-import os
+from quart import Quart
 from common.config import app
+from quart_schema import QuartSchema
 
 from routes import api_blueprint
 
-api = Flask(__name__)
+api = Quart(__name__)
 
 base_url = app.connector_api_base_url
 api.register_blueprint(api_blueprint, url_prefix=base_url)
+
+QuartSchema(api, openapi_path=base_url + "/openapi.json")
 
 if __name__ == "__main__":
     port = int(app.connector_api_port)

--- a/services/watson-extension/Pipfile
+++ b/services/watson-extension/Pipfile
@@ -11,7 +11,6 @@ logstash_formatter = "*"
 requests = "*"
 jwt = "*"
 common = {editable=true, path="../../libs/common/src"}
-quart-schema = "*"
 
 [dev-packages]
 pytest = "*"

--- a/services/watson-extension/Pipfile.lock
+++ b/services/watson-extension/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fad185ca7ebcd67f6d12d9ca9f986e9de9d3a182ba140a058a95b4bdbda1e8c1"
+            "sha256": "57da7edb9347b990999e629a2be99f42646b48466cda7962db1a548a30abcd00"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -977,7 +977,6 @@
                 "sha256:57b8f7d2f8cc5bcbf6b2200ed17f870fc26811c5d0ac5c6a02352644ab068129",
                 "sha256:5edcd18adb223c9d0f234688238882884fb09a4ee52fb29b50928821adbb7064"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==0.21.0"
         },


### PR DESCRIPTION
- Moving from flask to quart
- Adding QuartSchema so we get openapi definitions. Using the pydantic variant so we benefit from what we already have.

Some thoughts for a next pass here:
 - It would probably good to split routes in a different files and having the specific models in the same file (group by route vs group routes)
 - We could try to build the actual logic separate from the route code so that is easier to add some unit tests

