### PR TITLE
Support watson message types and changing API interface

### DIFF
--- a/services/virtual-assistant/src/virtual-assistant/api_types.py
+++ b/services/virtual-assistant/src/virtual-assistant/api_types.py
@@ -44,14 +44,29 @@ class TalkInput(BaseModel):
 
 class TalkRequest(BaseModel):
     session_id: Optional[str] = None
+    input: TalkInput
+
+
+class TalkResponseOptionsItems(BaseModel):
+    label: str
     input: Optional[TalkInput] = None
 
 
-class ApiResponse(BaseModel):
-    text: str
+class TalkResponseListItems(BaseModel):
+    text: Optional[str] = None
+    options: Optional[List[TalkResponseOptionsItems]] = None
 
 
-def watson_response_formatter(session_id: str, response: dict):
+class TalkResponse(BaseModel):
+    response: Optional[List[TalkResponseListItems]] = None
+    session_id: str
+
+
+class TalkRequestError(BaseModel):
+    message: str
+
+
+def watson_response_formatter(session_id: str, response: dict) -> TalkResponse:
     watson_generic = response["output"]["generic"]
     normalized_watson_response = []
 
@@ -84,4 +99,5 @@ def watson_response_formatter(session_id: str, response: dict):
         "session_id": session_id,
         "response": normalized_watson_response,
     }
-    return normalized_response
+
+    return TalkResponse(**normalized_response)

--- a/services/virtual-assistant/src/virtual-assistant/api_types.py
+++ b/services/virtual-assistant/src/virtual-assistant/api_types.py
@@ -32,7 +32,6 @@ class TalkRequestInputAnalytics(BaseModel):
 
 
 class TalkInput(BaseModel):
-    # TODO: update to support empty list `[]` for intents and entities key
     message_type: Optional[str] = None
     text: Optional[str] = None
     intents: Optional[List[TalkRequestInputIntents]] = None
@@ -57,21 +56,32 @@ def watson_response_formatter(session_id: str, response: dict):
     normalized_watson_response = []
 
     for generic in watson_generic:
-        print("generic", generic)
         if generic["response_type"] == "text":
             normalized_watson_response.append({"text": generic["text"]})
 
         if generic["response_type"] == "option":
             options = []
             for option in generic["options"]:
-                options.append({"label": option["label"], "input": option["value"].get("input")})
+                options.append(
+                    {"label": option["label"], "input": option["value"].get("input")}
+                )
             normalized_watson_response.append({"options": options})
 
         if generic["response_type"] == "suggestion":
             options = []
             for suggestion in generic["suggestions"]:
-                options.append({"label": suggestion["label"], "input": suggestion["value"].get("input")})
-            normalized_watson_response.append({"text": generic["title"], "options": options})
+                options.append(
+                    {
+                        "label": suggestion["label"],
+                        "input": suggestion["value"].get("input"),
+                    }
+                )
+            normalized_watson_response.append(
+                {"text": generic["title"], "options": options}
+            )
 
-    normalized_response = {"session_id": session_id, "response": normalized_watson_response}
+    normalized_response = {
+        "session_id": session_id,
+        "response": normalized_watson_response,
+    }
     return normalized_response

--- a/services/virtual-assistant/src/virtual-assistant/api_types.py
+++ b/services/virtual-assistant/src/virtual-assistant/api_types.py
@@ -1,13 +1,77 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 
 
-class TalkRequestMetadata(BaseModel):
-    session_id: Optional[str] = None
-    # account: str
-    # org_id: str
+class TalkRequestInputIntents(BaseModel):
+    intent: str
+    confidence: Optional[float] = None
+    skill: Optional[str] = None
+
+
+class TalkRequestInputEntities(BaseModel):
+    entity: str
+    location: Optional[List[int]] = []
+    value: str
+    confidence: Optional[float] = None
+    groups: Optional[dict] = {}
+    interpretation: Optional[dict] = {}
+    alternatives: Optional[dict] = {}
+    role: Optional[dict] = {}
+    skill: Optional[str] = {}
+
+
+class TalkRequestInputAttachments(BaseModel):
+    url: str
+    media_type: Optional[str] = None
+
+
+class TalkRequestInputAnalytics(BaseModel):
+    browser: Optional[str] = None
+    device: Optional[str] = None
+    page_url: Optional[str] = None
+
+
+class TalkInput(BaseModel):
+    # TODO: update to support empty list `[]` for intents and entities key
+    message_type: Optional[str] = None
+    text: Optional[str] = None
+    intents: Optional[List[TalkRequestInputIntents]] = None
+    entities: Optional[List[TalkRequestInputEntities]] = None
+    suggestion_id: Optional[str] = None
+    attachments: Optional[TalkRequestInputAttachments] = None
+    analytics: Optional[TalkRequestInputAnalytics] = None
+    options: Optional[dict] = None
 
 
 class TalkRequest(BaseModel):
-    message: str
-    metadata: TalkRequestMetadata
+    session_id: Optional[str] = None
+    input: Optional[TalkInput] = None
+
+
+class ApiResponse(BaseModel):
+    text: str
+
+
+def watson_response_formatter(session_id: str, response: dict):
+    watson_generic = response["output"]["generic"]
+    normalized_watson_response = []
+
+    for generic in watson_generic:
+        print("generic", generic)
+        if generic["response_type"] == "text":
+            normalized_watson_response.append({"text": generic["text"]})
+
+        if generic["response_type"] == "option":
+            options = []
+            for option in generic["options"]:
+                options.append({"label": option["label"], "input": option["value"].get("input")})
+            normalized_watson_response.append({"options": options})
+
+        if generic["response_type"] == "suggestion":
+            options = []
+            for suggestion in generic["suggestions"]:
+                options.append({"label": suggestion["label"], "input": suggestion["value"].get("input")})
+            normalized_watson_response.append({"text": generic["title"], "options": options})
+
+    normalized_response = {"session_id": session_id, "response": normalized_watson_response}
+    return normalized_response

--- a/services/virtual-assistant/src/virtual-assistant/routes.py
+++ b/services/virtual-assistant/src/virtual-assistant/routes.py
@@ -27,7 +27,7 @@ async def health():
 @api_blueprint.route("/talk", methods=["POST"])
 @require_identity_header
 async def talk():
-    data = request.get_json()
+    request_body = await request.get_json()
     identity = request.headers.get("x-rh-identity")
     org_id = get_org_id_from_identity(identity)
 

--- a/services/virtual-assistant/src/virtual-assistant/routes.py
+++ b/services/virtual-assistant/src/virtual-assistant/routes.py
@@ -34,7 +34,7 @@ async def health():
 @validate_request(TalkRequest)
 @validate_response(TalkResponse, 200)
 @validate_response(TalkRequestError, 400)
-async def talk(data: TalkRequest):
+async def talk(data: TalkRequest) -> TalkResponse:
     identity = request.headers.get("x-rh-identity")
     org_id = get_org_id_from_identity(identity)
 

--- a/services/virtual-assistant/src/virtual-assistant/routes.py
+++ b/services/virtual-assistant/src/virtual-assistant/routes.py
@@ -52,7 +52,6 @@ async def talk():
     print("session_id", session_id)
     watson_input = validated_request_body.input.dict(exclude_none=True)
     watson_input["message_type"] = "text"
-    print("watson_input", watson_input)
 
     # Send message to Watson Assistant
     watson_message_response = assistant.message(
@@ -66,4 +65,3 @@ async def talk():
     response = watson_response_formatter(session_id, watson_message_response)
     ## reformat watson message response to include session id and other things
     return jsonify(response), 200
-

--- a/services/virtual-assistant/src/virtual-assistant/routes.py
+++ b/services/virtual-assistant/src/virtual-assistant/routes.py
@@ -6,7 +6,7 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from common.config import app
 
 from common.auth import require_identity_header, get_org_id_from_identity
-from api_types import TalkRequest
+from api_types import TalkRequest, watson_response_formatter
 
 
 api_blueprint = Blueprint("api", __name__)
@@ -31,18 +31,18 @@ async def talk():
     identity = request.headers.get("x-rh-identity")
     org_id = get_org_id_from_identity(identity)
 
-    if not data:
+    if not request_body:
         return jsonify({"error": "No request body"}), 400
 
     try:
-        validated_data = TalkRequest(**data)
+        validated_request_body = TalkRequest(**request_body)
     except ValidationError as e:
         return jsonify({"errors": e.errors()}), 400
 
     assistant = get_watson_assistant()
 
     # Create session if not provided
-    session_id = validated_data.metadata.session_id
+    session_id = validated_request_body.session_id
     if not session_id:
         watson_session_response = assistant.create_session(
             assistant_id=app.watson_env_id
@@ -50,15 +50,20 @@ async def talk():
         session_id = watson_session_response["session_id"]
 
     print("session_id", session_id)
+    watson_input = validated_request_body.input.dict(exclude_none=True)
+    watson_input["message_type"] = "text"
+    print("watson_input", watson_input)
+
     # Send message to Watson Assistant
-    user_message = validated_data.message
     watson_message_response = assistant.message(
         assistant_id=app.watson_env_id,
         environment_id=app.watson_env_id,
         session_id=session_id,
         user_id=org_id,  # using org_id and user_id to identity unique users
-        input={"message_type": "text", "text": user_message},
+        input=validated_request_body.input.dict(exclude_none=True),
     ).get_result()
 
+    response = watson_response_formatter(session_id, watson_message_response)
     ## reformat watson message response to include session id and other things
-    return jsonify(watson_message_response), 200
+    return jsonify(response), 200
+

--- a/services/virtual-assistant/src/virtual-assistant/routes.py
+++ b/services/virtual-assistant/src/virtual-assistant/routes.py
@@ -1,12 +1,17 @@
 from quart import Blueprint, jsonify, request
-from pydantic import ValidationError
+from quart_schema import validate_request, validate_response
 from ibm_watson import AssistantV2
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_cloud_sdk_core.api_exception import ApiException
 
 from common.config import app
-
 from common.auth import require_identity_header, get_org_id_from_identity
-from api_types import TalkRequest, watson_response_formatter
+from api_types import (
+    TalkRequest,
+    TalkResponse,
+    TalkRequestError,
+    watson_response_formatter,
+)
 
 
 api_blueprint = Blueprint("api", __name__)
@@ -26,23 +31,17 @@ async def health():
 
 @api_blueprint.route("/talk", methods=["POST"])
 @require_identity_header
-async def talk():
-    request_body = await request.get_json()
+@validate_request(TalkRequest)
+@validate_response(TalkResponse, 200)
+@validate_response(TalkRequestError, 400)
+async def talk(data: TalkRequest):
     identity = request.headers.get("x-rh-identity")
     org_id = get_org_id_from_identity(identity)
-
-    if not request_body:
-        return jsonify({"error": "No request body"}), 400
-
-    try:
-        validated_request_body = TalkRequest(**request_body)
-    except ValidationError as e:
-        return jsonify({"errors": e.errors()}), 400
 
     assistant = get_watson_assistant()
 
     # Create session if not provided
-    session_id = validated_request_body.session_id
+    session_id = data.session_id
     if not session_id:
         watson_session_response = assistant.create_session(
             assistant_id=app.watson_env_id
@@ -50,18 +49,22 @@ async def talk():
         session_id = watson_session_response["session_id"]
 
     print("session_id", session_id)
-    watson_input = validated_request_body.input.dict(exclude_none=True)
+    watson_input = data.input.dict(exclude_none=True)
     watson_input["message_type"] = "text"
 
     # Send message to Watson Assistant
-    watson_message_response = assistant.message(
-        assistant_id=app.watson_env_id,
-        environment_id=app.watson_env_id,
-        session_id=session_id,
-        user_id=org_id,  # using org_id and user_id to identity unique users
-        input=validated_request_body.input.dict(exclude_none=True),
-    ).get_result()
+    watson_message_response = None
+    try:
+        watson_message_response = assistant.message(
+            assistant_id=app.watson_env_id,
+            environment_id=app.watson_env_id,
+            session_id=session_id,
+            user_id=org_id,  # using org_id and user_id to identity unique users
+            input=data.input.dict(exclude_none=True),
+        ).get_result()
+    except ApiException as e:
+        return TalkRequestError(message=e.message), 400
 
     response = watson_response_formatter(session_id, watson_message_response)
-    ## reformat watson message response to include session id and other things
-    return jsonify(response), 200
+
+    return response, 200

--- a/services/virtual-assistant/src/virtual-assistant/run.py
+++ b/services/virtual-assistant/src/virtual-assistant/run.py
@@ -1,13 +1,21 @@
 from quart import Quart
 from common.config import app
-from quart_schema import QuartSchema
+from quart_schema import QuartSchema, RequestSchemaValidationError
 
 from routes import api_blueprint
+from api_types import TalkRequestError
+
 
 api = Quart(__name__)
 
 base_url = app.connector_api_base_url
 api.register_blueprint(api_blueprint, url_prefix=base_url)
+
+
+@api.errorhandler(RequestSchemaValidationError)
+async def handle_request_validation_error(error):
+    return TalkRequestError(message=str(error.validation_error)), 400
+
 
 QuartSchema(api, openapi_path=base_url + "/openapi.json")
 


### PR DESCRIPTION
- supports the ingestion of `text`, `suggestions`, `options` message types sent down by watson.
- Changed the API interface to respond to differnt options sent down by the `suggestions` and `options` message types.
- Handling validation through quartschema

**Request body for `/talk`**
```javascript
//starting a conversation
{
    "input": {
        "text": "<<text>>"
    }
}

OR

// Respond to a suggestions/options message type; the suggestions/options message types returns a list of possible input, just copy one from the list
{
    "input": {
        "entities": [],
        "intents": [
            {
                "confidence": 1,
                "intent": "action_39973_intent_36830"
            }
        ],
        "suggestion_id": "d:e807709d-e6c8-4d39-81fa-5dfc495f2f87",
        "text": "api docs"
    },
    "session_id": "<<session_id>>"
}
```

**Response from `/talk`**
```javascript
{
    "response": [
        {
            "text": "API docs intent"
        },
        {
            "options": [
               // List of possible inputs that can be used to respond
                {
                    "input": {<<input>>},
                    "label": "<<input name/button display name>>"
                },
                {
                    "input": {<<input>>},
                    "label": "<<input name/button display name>>"
                }
            ]
        }
    ],
    "session_id": "<<session_id>>"
}
```