### PR TITLE
Add CronJob template for iqe-tests:astro-va

### DIFF
--- a/deploy/iqe-job-template.yaml
+++ b/deploy/iqe-job-template.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: astro-va-test-schedule
+objects:
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    name: astro-va-test
+    annotations:
+      "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+      "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+  spec:
+    schedule: ${CRON_SCHEDULE}
+    jobTemplate:
+      spec:
+        imagePullSecrets:
+        - name: quay-cloudservices-pull
+        restartPolicy: Never
+        volumes:
+        - name: sel-shm
+          emptyDir:
+            medium: Memory
+        containers:
+        - name: astro-va-${NAME_STUB}-${IMAGE_TAG}-${UID}
+          image: ${IQE_IMAGE}:${IQE_IMAGE_TAG}
+          imagePullPolicy: Always
+          args:
+          - run
+          env:
+          - name: ENV_FOR_DYNACONF
+            value: ${ENV_FOR_DYNACONF}
+          - name: DYNACONF_MAIN__use_beta
+            value: ${USE_BETA}
+          - name: IQE_IBUTSU_SOURCE
+            value: astro-saas-timer-${IMAGE_TAG}-${UID}
+          - name: IQE_BROWSERLOG
+            value: ${IQE_BROWSERLOG}
+          - name: IQE_NETLOG
+            value: ${IQE_NETLOG}
+          - name: IQE_PLUGINS
+            value: ${IQE_PLUGINS}
+          - name: IQE_MARKER_EXPRESSION
+            value: ${IQE_MARKER_EXPRESSION}
+          - name: IQE_FILTER_EXPRESSION
+            value: ${IQE_FILTER_EXPRESSION}
+          - name: IQE_LOG_LEVEL
+            value: ${IQE_LOG_LEVEL}
+          - name: IQE_REQUIREMENTS
+            value: ${IQE_REQUIREMENTS}
+          - name: IQE_REQUIREMENTS_PRIORITY
+            value: ${IQE_REQUIREMENTS_PRIORITY}
+          - name: IQE_TEST_IMPORTANCE
+            value: ${IQE_TEST_IMPORTANCE}
+          - name: DYNACONF_IQE_VAULT_LOADER_ENABLED
+            value: "true"
+          - name: DYNACONF_IQE_VAULT_VERIFY
+            value: "true"
+          - name: DYNACONF_IQE_VAULT_URL
+            valueFrom:
+              secretKeyRef:
+                key: url
+                name: iqe-vault
+                optional: true
+          - name: DYNACONF_IQE_VAULT_MOUNT_POINT
+            valueFrom:
+              secretKeyRef:
+                key: mountPoint
+                name: iqe-vault
+                optional: true
+          - name: DYNACONF_IQE_VAULT_ROLE_ID
+            valueFrom:
+              secretKeyRef:
+                key: roleId
+                name: iqe-vault
+                optional: true
+          - name: DYNACONF_IQE_VAULT_SECRET_ID
+            valueFrom:
+              secretKeyRef:
+                key: secretId
+                name: iqe-vault
+                optional: true
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1.5Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - name: iqe-sel-${IMAGE_TAG}-${UID}
+          image: ${IQE_SEL_IMAGE}
+          env:
+            - name: _JAVA_OPTIONS
+              value: ${SELENIUM_JAVA_OPTS}
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - name: sel-shm
+              mountPath: /dev/shm
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique job name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"
+- name: CRON_SCHEDULE
+  description: "Schedule for cron job"
+  value: '15 2,14 * * *'
+  required: true
+- name: IQE_IMAGE
+  description: "container image path for the iqe plugin"
+  value: quay.io/cloudservices/iqe-tests
+- name: IQE_IMAGE_TAG
+  description: "container image tag for iqe plugin"
+  value: 'astro-va'
+- name: ENV_FOR_DYNACONF
+  value: stage_proxy
+- name: USE_BETA
+  value: "true"
+- name: IQE_PLUGINS
+  value: 'astro_va'
+- name: IQE_MARKER_EXPRESSION
+  value: 'core'
+- name: IQE_FILTER_EXPRESSION
+  value: ''
+- name: IQE_LOG_LEVEL
+  value: info
+- name: IQE_REQUIREMENTS
+  value: ''
+- name: IQE_REQUIREMENTS_PRIORITY
+  value: ''
+- name: IQE_TEST_IMPORTANCE
+  value: ''
+- name: IQE_SEL_IMAGE
+  value: 'quay.io/redhatqe/selenium-standalone:ff_91.9.1esr_chrome_103.0.5060.114'
+- name: IQE_BROWSERLOG
+  value: "1"
+- name: IQE_NETLOG
+  value: "1"
+- name: NAME_STUB
+  value: 'astro-core'
+- name: SELENIUM_JAVA_OPTS
+  value: ''


### PR DESCRIPTION
This can be utilized in kube/ocp environments to create a cronjob that takes parameters to tweak the execution of the job and the IQE pod within it.

None of the CI failures are related to this file's presence or content. 

This has to be merged before the relevant AppSRE MR that includes the resourceTarget for SAAS deployment. 

- [x] https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/140849 
- [ ] https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/141120 (This must be merged for this MR's CI to pass)
